### PR TITLE
Update PLAYLIST_REGEX

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -2,7 +2,7 @@ const fetch = typeof window !== "undefined" && window.fetch || require("node-fet
 const Channel = require("./Structures/Channel");
 const Playlist = require("./Structures/Playlist");
 const Video = require("./Structures/Video");
-const PLAYLIST_REGEX = /https?:\/\/(www.)?youtube.com\/playlist\?list=((PL|UU|LL|RD)[a-zA-Z0-9-_]{16,41})/;
+const PLAYLIST_REGEX = /https?:\/\/(www.)?youtube.com\/.*\?.*\blist=((PL|UU|LL|RD)[a-zA-Z0-9-_]{16,41})/;
 const PLAYLIST_ID = /(PL|UU|LL|RD)[a-zA-Z0-9-_]{16,41}/;
 
 class Util {


### PR DESCRIPTION
Update PLAYLIST_REGEX so playlist like this [example](https://www.youtube.com/watch?v=x8VYWazR5mE&list=PL_A7IF_b8OCR7k9CZovjSoW1Sv99NQYIJ), which begins with a `watch?v=` and contains a `list=`, are still treated as a playlist and not as an individual video.