### PR TITLE
fix thumbnail object on playlist parsing

### DIFF
--- a/src/Util.ts
+++ b/src/Util.ts
@@ -221,7 +221,12 @@ class Util {
         const res = new Playlist({
             id: data.playlistRenderer.playlistId,
             title: data.playlistRenderer.title.simpleText,
-            thumbnail: data.playlistRenderer.thumbnails[0].thumbnails[data.playlistRenderer.thumbnails[0].thumbnails.length - 1].url,
+            thumbnail: {
+                id: data.playlistRenderer.playlistId,
+                url: data.playlistRenderer.thumbnails[0].thumbnails[data.playlistRenderer.thumbnails[0].thumbnails.length - 1].url,
+                height: data.playlistRenderer.thumbnails[0].thumbnails[data.playlistRenderer.thumbnails[0].thumbnails.length - 1].height,
+                width: data.playlistRenderer.thumbnails[0].thumbnails[data.playlistRenderer.thumbnails[0].thumbnails.length - 1].width,
+            },
             channel: {
                 id: data.playlistRenderer.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId,
                 name: data.playlistRenderer.shortBylineText.runs[0].text,


### PR DESCRIPTION
Closes #17 

I had left some others points there, but now that I'm looking at how this is implemented, I don't think the others are fixable. 

This were the notes:

> Notes:
> * `thumbnail` property is intended to be a `Thumbnail` object, but it's a string instead
> * `channel` property object is missing following properties: `verified`, `icon`, `subscribers`. (`icon` is the ~~only~~ most important for me)
> * `lastUpdate` is being always `undefined`. I know it's tagged as nullable, but is there a way to get it, or even something like `uploadedAt` or `createdAt` in a reliable way?
> * `videos` array is empty 🙁

✔ `thumbail` is being fixed with this PR
❌ `channel` icon info doesn't seem to be included in this query (seen image bellow).
❌ `lastUpdate` same as `channel`
![image](https://user-images.githubusercontent.com/20830847/116487297-f590c180-a865-11eb-9b62-d0b0a200d9a2.png)
❌ `videos`: actually there's info about only two videos, but I thinks it's okay to not have video info about 100 videos on a query that is supposed to fetch at max 20 results. This info can be lazily fetch later using `getPlaylits()`
