### PR TITLE
Update youtube query url

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,7 @@ class YouTube {
         options.type = options.type || "video";
         
         const filter = options.type === "all" ? "" : `&sp=${Util.filter(options.type)}`;
-        const url = `https://youtube.com/results?q=${encodeURI(query.trim())}&hl=en${filter}`;
+        const url = `https://youtube.com/results?q=${query.trim().replace(/ /g, '+')}&hl=en${filter}`;
         const requestOptions = options.safeSearch ? { ...options.requestOptions, headers: { cookie: SAFE_SEARCH_COOKIE } } : {};
 
         const html = await Util.getHTML(url, requestOptions);

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,10 @@ class YouTube {
         options.type = options.type || "video";
         
         const filter = options.type === "all" ? "" : `&sp=${Util.filter(options.type)}`;
-        const url = `https://youtube.com/results?q=${query.trim().replace(/ /g, '+')}&hl=en${filter}`;
+        
+        const searchQuery = query.trim().replace(/ /g, '+').replace(/&/g, '%26');
+
+        const url = `https://youtube.com/results?q=${searchQuery}&hl=en${filter}`;
         const requestOptions = options.safeSearch ? { ...options.requestOptions, headers: { cookie: SAFE_SEARCH_COOKIE } } : {};
 
         const html = await Util.getHTML(url, requestOptions);

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,10 +48,8 @@ class YouTube {
         options.type = options.type || "video";
         
         const filter = options.type === "all" ? "" : `&sp=${Util.filter(options.type)}`;
-        
-        const searchQuery = query.trim().replace(/ /g, '+').replace(/&/g, '%26');
 
-        const url = `https://youtube.com/results?q=${searchQuery}&hl=en${filter}`;
+        const url = `https://youtube.com/results?q=${encodeURI(query.trim()).replace(/%20/g, '+')}&hl=en${filter}`;
         const requestOptions = options.safeSearch ? { ...options.requestOptions, headers: { cookie: SAFE_SEARCH_COOKIE } } : {};
 
         const html = await Util.getHTML(url, requestOptions);


### PR DESCRIPTION
The query search for the Youtube URL has been changed. 
The Youtube URL is built differently and does not use the standard URL encoding.
In the query part only the spaces are changed to + characters.

This extremely changes the search results and you get wrong answers.